### PR TITLE
limit main area height to "screen"

### DIFF
--- a/resources/js/components/board/Board.vue
+++ b/resources/js/components/board/Board.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="flex flex-col h-screen">
     <MainNavBar :borderColor="borderColor"></MainNavBar>
     <div
       class="h-screen flex overflow-hidden"


### PR DESCRIPTION
@shaunthornburgh I've added classes to fix screen height, please check it when you have time.

I was unable to add cards because SQLite for some reason returned owner_id as a string so the policy didn't work correctly. Switched to MySQL and everything work now.

Duplicating cards after drag is possibly related to the fact that the cards list is in a prop. When copying from prop to data this bug is not happening, but we need to change some events. Will try to finish it tomorrow.